### PR TITLE
Add disconnect command to cleanup

### DIFF
--- a/lib/setup-cloudflare-warp.js
+++ b/lib/setup-cloudflare-warp.js
@@ -164,9 +164,13 @@ export async function run() {
 export async function cleanup() {
   switch (process.platform) {
     case "linux":
+      await exec.exec("warp-cli disconnect");
       await exec.exec("sudo rm /var/lib/cloudflare-warp/mdm.xml");
       break;
     case "darwin":
+      await exec.exec(
+        'warp-cli disconnect',
+      );
       await exec.exec(
         'sudo rm "/Library/Managed Preferences/com.cloudflare.warp.plist"',
       );

--- a/lib/setup-cloudflare-warp.js
+++ b/lib/setup-cloudflare-warp.js
@@ -162,15 +162,12 @@ export async function run() {
 }
 
 export async function cleanup() {
+  await exec.exec("warp-cli", ["--accept-tos", "disconnect"]);
   switch (process.platform) {
     case "linux":
-      await exec.exec("warp-cli disconnect");
       await exec.exec("sudo rm /var/lib/cloudflare-warp/mdm.xml");
       break;
     case "darwin":
-      await exec.exec(
-        'warp-cli disconnect',
-      );
       await exec.exec(
         'sudo rm "/Library/Managed Preferences/com.cloudflare.warp.plist"',
       );


### PR DESCRIPTION
Adds `warp-cli disconnect` command to the cleanup function as it can take too long as mentioned by this [issue](https://github.com/Boostport/setup-cloudflare-warp/issues/53#issue-2230538877). 