### PR TITLE
fix: Adjust backoff settings to only retry 10 times and max out at 4 seconds per retry

### DIFF
--- a/lib/setup-cloudflare-warp.js
+++ b/lib/setup-cloudflare-warp.js
@@ -4,6 +4,11 @@ import * as fs from "fs";
 import * as tc from "@actions/tool-cache";
 import { backOff } from "exponential-backoff";
 
+const backoffOptions = {
+  numOfAttempts: 10,
+  maxDelay: 4000,
+};
+
 async function installLinuxClient(version) {
   const gpgKeyPath = await tc.downloadTool(
     "https://pkg.cloudflareclient.com/pubkey.gpg",
@@ -153,11 +158,12 @@ export async function run() {
       break;
   }
 
-  await backOff(() => checkWARPRegistration(organization, true), {
-    numOfAttempts: 20,
-  });
+  await backOff(
+    () => checkWARPRegistration(organization, true),
+    backoffOptions,
+  );
   await exec.exec("warp-cli", ["--accept-tos", "connect"]);
-  await backOff(() => checkWARPConnected(), { numOfAttempts: 20 });
+  await backOff(() => checkWARPConnected(), backoffOptions);
   core.saveState("connected", "true");
 }
 
@@ -176,6 +182,9 @@ export async function cleanup() {
   const connected = !!core.getState("connected");
   if (connected) {
     const organization = core.getInput("organization", { required: true });
-    await backOff(() => checkWARPRegistration(organization, false));
+    await backOff(
+      () => checkWARPRegistration(organization, false),
+      backoffOptions,
+    );
   }
 }


### PR DESCRIPTION
Due to the exponential backoff, in a failure scenario this action can currently run for hours (we saw a run going for 5
hours retrying before being cancelled. This PR reduces the retries to 10, and makes the backoff top out at 4 seconds.
