### PR TITLE
fix: retry connect on registration missing

### DIFF
--- a/lib/setup-cloudflare-warp.js
+++ b/lib/setup-cloudflare-warp.js
@@ -120,6 +120,12 @@ async function checkWARPConnected() {
 
   await exec.exec("warp-cli", ["--accept-tos", "status"], options);
 
+  // Retry connect on missing registration
+  if (output.includes("Reason: Registration Missing")) {
+    await exec.exec("warp-cli", ["--accept-tos", "connect"]);
+    await exec.exec("warp-cli", ["--accept-tos", "status"], options);
+  }
+
   if (!output.includes("Status update: Connected")) {
     throw new Error("WARP is not connected");
   }


### PR DESCRIPTION
We sporadically have test runs where this action fails with Registration missing. Once you are
in that state the connection never completes

This PR re-tries connect when we see this state, confirmed to fix retries in our pipelines.
