### PR TITLE
feat: Add support for windows, backported from oHTGo/setup-cloudflare-warp-action

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -24,7 +24,7 @@ jobs:
     needs: ["approve-pr-tests", "lint"]
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -36,4 +36,4 @@ jobs:
           organization: ${{ secrets.CLOUDFLARE_ACCESS_ORGANIZATION }}
           auth_client_id: ${{ secrets.CLOUDFLARE_ACCESS_CLIENT_ID }}
           auth_client_secret: ${{ secrets.CLOUDFLARE_ACCESS_CLIENT_SECRET }}
-      - run: wget https://www.google.com
+      - run: curl -I https://www.google.com

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -24,4 +24,4 @@ jobs:
         organization: ${{ secrets.CLOUDFLARE_ACCESS_ORGANIZATION }}
         auth_client_id: ${{ secrets.CLOUDFLARE_ACCESS_CLIENT_ID }}
         auth_client_secret: ${{ secrets.CLOUDFLARE_ACCESS_CLIENT_SECRET }}
-    - run: wget https://www.google.com
+    - run: curl -I https://www.google.com

--- a/lib/setup-cloudflare-warp.js
+++ b/lib/setup-cloudflare-warp.js
@@ -37,6 +37,15 @@ async function installMacOSClient(version) {
   }
 }
 
+async function installWindowsClient(version) {
+  if (version) {
+    await exec.exec(`choco install -y warp --no-progress --version=${version}`);
+  } else {
+    await exec.exec("choco install -y --no-progress warp");
+  }
+  core.addPath("C:\\Program Files\\Cloudflare\\Cloudflare WARP\\");
+}
+
 async function writeLinuxConfiguration(
   organization,
   auth_client_id,
@@ -90,6 +99,25 @@ async function writeMacOSConfiguration(
   );
 }
 
+async function writeWindowsConfiguration(
+  organization,
+  auth_client_id,
+  auth_client_secret,
+) {
+  const config = `
+<dict>
+    <key>organization</key>
+    <string>${organization}</string>
+    <key>auth_client_id</key>
+    <string>${auth_client_id}</string>
+    <key>auth_client_secret</key>
+    <string>${auth_client_secret}</string>
+</dict>`;
+  if (!fs.existsSync("C:\\ProgramData\\Cloudflare"))
+    fs.mkdirSync("C:\\ProgramData\\Cloudflare");
+  fs.writeFileSync("C:\\ProgramData\\Cloudflare\\mdm.xml", config);
+}
+
 async function checkWARPRegistration(organization, is_registered) {
   let output = "";
   const options = {};
@@ -132,9 +160,11 @@ async function checkWARPConnected() {
 }
 
 export async function run() {
-  if (!["linux", "darwin"].includes(process.platform)) {
+  if (!["linux", "darwin", "win32"].includes(process.platform)) {
     throw new Error(
-      "Only Linux and macOS are supported. Pull requests for other platforms are welcome.",
+      "Only Windows, Linux and macOS are supported. Pull requests for other platforms are welcome. (Platform is " +
+        process.platform +
+        ")",
     );
   }
 
@@ -162,6 +192,14 @@ export async function run() {
       );
       await installMacOSClient(version);
       break;
+    case "win32":
+      await writeWindowsConfiguration(
+        organization,
+        auth_client_id,
+        auth_client_secret,
+      );
+      await installWindowsClient(version);
+      break;
   }
 
   await backOff(
@@ -182,6 +220,9 @@ export async function cleanup() {
       await exec.exec(
         'sudo rm "/Library/Managed Preferences/com.cloudflare.warp.plist"',
       );
+      break;
+    case "win32":
+      await exec.exec("rm C:\\ProgramData\\Cloudflare\\mdm.xml");
       break;
   }
 


### PR DESCRIPTION
Tested on github managed `windows-latest` runner.
