### PR TITLE
Check if installed, proper deregistration

### DIFF
--- a/lib/setup-cloudflare-warp.js
+++ b/lib/setup-cloudflare-warp.js
@@ -28,7 +28,26 @@ function jsonToXml(config) {
   return xml;
 }
 
+async function checkWarpCliExists() {
+  try {
+    if (process.platform === "win32") {
+      await exec.exec("where warp-cli");
+    } else {
+      await exec.exec("which warp-cli");
+    }
+    core.info("warp-cli already exists, skipping installation");
+    return true;
+  } catch {
+    core.info("warp-cli not found, proceeding with installation");
+    return false;
+  }
+}
+
 async function installLinuxClient(version) {
+  if (await checkWarpCliExists()) {
+    return;
+  }
+
   const gpgKeyPath = await tc.downloadTool(
     "https://pkg.cloudflareclient.com/pubkey.gpg",
   );
@@ -48,6 +67,10 @@ async function installLinuxClient(version) {
 }
 
 async function installMacOSClient(version) {
+  if (await checkWarpCliExists()) {
+    return;
+  }
+
   await exec.exec("brew update");
   if (version === "") {
     await exec.exec("brew install --cask cloudflare-warp");
@@ -57,6 +80,10 @@ async function installMacOSClient(version) {
 }
 
 async function installWindowsClient(version) {
+  if (await checkWarpCliExists()) {
+    return;
+  }
+
   if (version) {
     await exec.exec(`choco install -y warp --no-progress --version=${version}`);
   } else {
@@ -278,16 +305,20 @@ export async function run() {
 }
 
 export async function cleanup() {
+  await exec.exec("warp-cli", ["--accept-tos", "disconnect"]);
   switch (process.platform) {
     case "linux":
+      await exec.exec("sudo warp-cli", ["--accept-tos", "registration", "delete"]);
       await exec.exec("sudo rm /var/lib/cloudflare-warp/mdm.xml");
       break;
     case "darwin":
+      await exec.exec("sudo warp-cli", ["--accept-tos", "registration", "delete"]);
       await exec.exec(
         'sudo rm "/Library/Managed Preferences/com.cloudflare.warp.plist"',
       );
       break;
     case "win32":
+      await exec.exec("warp-cli", ["--accept-tos", "registration", "delete"]);
       await exec.exec("rm C:\\ProgramData\\Cloudflare\\mdm.xml");
       break;
   }


### PR DESCRIPTION
- checking if the bin is installed is highly useful - if a user adds their own caching for the bin, then there's about 40s of gains.
- deregistering with the warp-cli prior to removing the config files
