### PR TITLE
fix: Download deb packages from downloads.cloudflareclient.com

### DIFF
--- a/lib/setup-cloudflare-warp.js
+++ b/lib/setup-cloudflare-warp.js
@@ -43,8 +43,39 @@ async function checkWarpCliExists() {
   }
 }
 
+/**
+ * Install deb from downloads.cloudflareclient.com
+ * Ref: https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/download-warp/#linux
+*/
+async function installLinuxDeb(version) {
+  const archMap = {
+    x64: "intel",
+    arm64: "arm",
+  }
+  const distroCodeName = (await exec.getExecOutput("lsb_release", ["-c"])).stdout.split(":")[1].trim();
+  const distroAndArch = `${distroCodeName}-${archMap[process.arch]}`;
+  const url = `https://downloads.cloudflareclient.com/v1/download/${distroAndArch}/version/${version}`;
+  core.info(`Downloading from url=${url}`);
+  const debPath = await tc.downloadTool(url, "warp.deb");
+  if (!debPath) {
+    throw new Error(`Failed to download Cloudflare WARP version ${version}`);
+  }
+
+  // Disable man-page processing
+  await exec.exec(`bash -c "echo 'set man-db/auto-update false' | sudo debconf-communicate"`);
+  await exec.exec("sudo rm /var/lib/man-db/auto-update");
+
+  await exec.exec("sudo apt-get update");
+  await exec.exec(`sudo apt-get install -y --no-install-recommends ./${debPath}`);
+}
+
 async function installLinuxClient(version) {
   if (await checkWarpCliExists()) {
+    return;
+  }
+
+  if (version !== "") {
+    await installLinuxDeb(version);
     return;
   }
 
@@ -57,13 +88,8 @@ async function installLinuxClient(version) {
   await exec.exec(
     '/bin/bash -c "echo \\"deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ $(lsb_release -cs) main\\" | sudo tee /etc/apt/sources.list.d/cloudflare-client.list"',
   );
-  await exec.exec("sudo apt update");
-
-  if (version === "") {
-    await exec.exec("sudo apt install -y cloudflare-warp");
-  } else {
-    await exec.exec(`sudo apt install -y cloudflare-warp=${version}*`);
-  }
+  await exec.exec("sudo apt-get update");
+  await exec.exec("sudo apt-get install -y cloudflare-warp");
 }
 
 async function installMacOSClient(version) {


### PR DESCRIPTION
Allows working around regression in latest warp client, see #208

Also disables man page processing