### PR TITLE
feat: add docker_bip and address pool inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ with:
   vnet: ${{ secrets.CLOUDFLARE_VNET }}
 ```
 
+On Linux, you can configure Docker to resolve DNS through Cloudflare WARP. If Docker's default address ranges
+(`172.17.0.0/16` for the default bridge, and the ranges used for user-defined networks) overlap with networks routed
+through your Zero Trust organization, use `docker_bip` to move the default bridge (the DNS resolver IP is derived
+from it) and `docker_default_address_pools` to move user-defined networks (e.g. those created by Docker Compose):
+```yaml
+uses: Boostport/setup-cloudflare-warp@v1
+with:
+  organization: your-organization
+  auth_client_id: ${{ secrets.CLOUDFLARE_AUTH_CLIENT_ID }}
+  auth_client_secret: ${{ secrets.CLOUDFLARE_AUTH_CLIENT_SECRET }}
+  configure_docker_dns: true
+  docker_bip: 192.168.200.1/24
+  docker_default_address_pools: 192.168.204.0/22,24
+```
+
+> [!NOTE]
+> `docker_default_address_pools` only affects networks created after this action runs, such as networks created by
+> `docker compose` or `docker network create` in later steps. Job containers (`container:`) and service containers
+> (`services:`) run on networks created before workflow steps execute, so this action cannot change their subnets;
+> that requires Docker daemon configuration at runner provisioning time.
+
 ## Inputs
 - `version` - (optional) The version of Cloudflare WARP to install. Defaults to the latest version.
 - `organization` - (required) The name of your Cloudflare Zero Trust organization.
@@ -55,6 +76,8 @@ with:
 - `auth_client_secret` - (required) The service token client secret.
 - `unique_client_id` - (optional) A unique identifier for the client device. See [Cloudflare documentation](https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/deployment/mdm-deployment/parameters/#unique_client_id) for more details.
 - `configure_docker_dns` - (optional) *Linux Only* Configure Docker to use Cloudflare WARP for DNS resolution. Defaults to `false`.
+- `docker_bip` - (optional) *Linux Only* Bridge IP for the default Docker network in CIDR notation (e.g. `192.168.200.1/24`). Sets the `bip` in the Docker daemon configuration and uses its address as the DNS resolver IP instead of `172.17.0.1`. Requires `configure_docker_dns` to be enabled.
+- `docker_default_address_pools` - (optional) *Linux Only* Address pools for Docker user-defined networks, as one or more `<base-cidr>,<subnet-size>` pairs separated by semicolons (e.g. `192.168.204.0/22,24` or `192.168.204.0/22,24;10.99.0.0/16,24`). Sets `default-address-pools` in the Docker daemon configuration. Only affects networks created after this action runs. Requires `configure_docker_dns` to be enabled.
 - `vnet` - (optional) Virtual network ID
 
 ## Cloudflare Permissions

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,12 @@ inputs:
   configure_docker_dns:
     description: 'Configure Docker to use Cloudflare WARP for DNS resolution'
     default: 'false'
+  docker_bip:
+    description: 'Bridge IP for the default Docker network in CIDR notation (e.g. 192.168.200.1/24). Sets the bip in the Docker daemon configuration and uses its address as the DNS resolver IP. Requires configure_docker_dns to be enabled.'
+    required: false
+  docker_default_address_pools:
+    description: 'Address pools for Docker user-defined networks, as one or more "<base-cidr>,<subnet-size>" pairs separated by semicolons (e.g. 192.168.204.0/22,24). Sets default-address-pools in the Docker daemon configuration. Only affects networks created after this action runs. Requires configure_docker_dns to be enabled.'
+    required: false
   unique_client_id:
     description: 'A unique identifier for the client device'
     required: false

--- a/lib/setup-cloudflare-warp.js
+++ b/lib/setup-cloudflare-warp.js
@@ -2,6 +2,7 @@ import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import * as fs from "fs/promises";
 import * as tc from "@actions/tool-cache";
+import { isIPv4 } from "net";
 import { backOff } from "exponential-backoff";
 
 const backoffOptions = {
@@ -208,25 +209,71 @@ async function writeWindowsConfiguration(
   await fs.writeFile("C:\\ProgramData\\Cloudflare\\mdm.xml", config);
 }
 
-async function configureLinuxDockerDNS() {
+function validateIPv4Cidr(cidr) {
+  const parts = cidr.split("/");
+  if (parts.length !== 2) {
+    return false;
+  }
+  const [address, prefix] = parts;
+  return (
+    isIPv4(address) &&
+    /^\d{1,2}$/.test(prefix) &&
+    Number(prefix) >= 1 &&
+    Number(prefix) <= 32
+  );
+}
+
+// Parses semicolon-separated "<base-cidr>,<subnet-size>" pools (e.g. "192.168.204.0/22,24") into [{ base, size }], or returns null if invalid
+function parseDockerAddressPools(input) {
+  const pools = [];
+  for (const pool of input.split(";")) {
+    const parts = pool.split(",");
+    if (parts.length !== 2) {
+      return null;
+    }
+    const base = parts[0].trim();
+    const size = Number(parts[1].trim());
+    if (!validateIPv4Cidr(base) || !Number.isInteger(size)) {
+      return null;
+    }
+    const basePrefix = Number(base.split("/")[1]);
+    if (size < basePrefix || size > 32) {
+      return null;
+    }
+    pools.push({ base, size });
+  }
+  return pools;
+}
+
+async function configureLinuxDockerDNS(docker_bip, dockerAddressPools) {
   // Set up resolved DNS stub listener on alternative IP as docker does not support DNS servers on 127.x.x.x
+  // The listener IP is the default docker bridge gateway, which is derived from the bip when one is set
+  const dnsIP = docker_bip === "" ? "172.17.0.1" : docker_bip.split("/")[0];
+  let daemonConfig = {};
   try {
-    await fs.stat("/etc/docker/daemon.json");
+    daemonConfig = JSON.parse(
+      await fs.readFile("/etc/docker/daemon.json", "utf8"),
+    );
   } catch (err) {
-    if (err.code === "ENOENT") {
-      await exec.exec(
-        `/bin/bash -c "echo '{}' | sudo tee /etc/docker/daemon.json"`,
-      );
+    if (err.code !== "ENOENT") {
+      throw err;
     }
   }
+  if (docker_bip !== "") {
+    daemonConfig.bip = docker_bip;
+  }
+  if (dockerAddressPools) {
+    daemonConfig["default-address-pools"] = dockerAddressPools;
+  }
+  daemonConfig.dns = [dnsIP];
+  await fs.writeFile("/tmp/daemon.json", JSON.stringify(daemonConfig, null, 2));
+  await exec.exec("sudo mv /tmp/daemon.json /etc/docker/daemon.json");
   await exec.exec(
-    `/bin/bash -c "echo "DNSStubListenerExtra=172.17.0.1" | sudo tee -a /etc/systemd/resolved.conf"`,
+    `/bin/bash -c "echo "DNSStubListenerExtra=${dnsIP}" | sudo tee -a /etc/systemd/resolved.conf"`,
   );
-  await exec.exec(
-    `/bin/bash -c "cat /etc/docker/daemon.json | jq '.dns=[\\"172.17.0.1\\"]' | sudo tee /etc/docker/daemon.json"`,
-  );
-  await exec.exec("sudo systemctl restart systemd-resolved");
+  // Restart docker first so the bridge IP exists before resolved binds the stub listener to it
   await exec.exec("sudo systemctl restart docker");
+  await exec.exec("sudo systemctl restart systemd-resolved");
 }
 
 async function checkWARPRegistration(organization, is_registered) {
@@ -291,12 +338,37 @@ export async function run() {
   const configure_docker_dns = core.getBooleanInput("configure_docker_dns", {
     required: false,
   });
+  const docker_bip = core.getInput("docker_bip", { required: false });
+  const docker_default_address_pools = core.getInput(
+    "docker_default_address_pools",
+    { required: false },
+  );
   const vnet = core.getInput("vnet", { required: false });
+
+  if (docker_bip !== "" && !validateIPv4Cidr(docker_bip)) {
+    throw new Error(
+      `docker_bip must be an IPv4 address in CIDR notation (e.g. 192.168.200.1/24), got: ${docker_bip}`,
+    );
+  }
+
+  let dockerAddressPools = null;
+  if (docker_default_address_pools !== "") {
+    dockerAddressPools = parseDockerAddressPools(docker_default_address_pools);
+    if (!dockerAddressPools) {
+      throw new Error(
+        `docker_default_address_pools must be one or more "<base-cidr>,<subnet-size>" pools separated by semicolons (e.g. 192.168.204.0/22,24), got: ${docker_default_address_pools}`,
+      );
+    }
+  }
 
   switch (process.platform) {
     case "linux":
       if (configure_docker_dns) {
-        await configureLinuxDockerDNS();
+        await configureLinuxDockerDNS(docker_bip, dockerAddressPools);
+      } else if (docker_bip !== "" || dockerAddressPools) {
+        core.warning(
+          "docker_bip and docker_default_address_pools have no effect because configure_docker_dns is not enabled",
+        );
       }
       await writeLinuxConfiguration(
         organization,


### PR DESCRIPTION
Docker's default ranges (172.17.0.0/16 bridge, user-defined network pools) can overlap networks routed through Cloudflare Zero Trust, which breaks container traffic when WARP is connected.