### PR TITLE
feature: wait indefinitely for dpkg lock

### DIFF
--- a/lib/setup-cloudflare-warp.js
+++ b/lib/setup-cloudflare-warp.js
@@ -66,8 +66,8 @@ async function installLinuxDeb(version) {
   await exec.exec(`bash -c "echo 'set man-db/auto-update false' | sudo debconf-communicate"`);
   await exec.exec("sudo rm -f /var/lib/man-db/auto-update");
 
-  await exec.exec("sudo apt-get update");
-  await exec.exec(`sudo apt-get install -y --no-install-recommends ./${debPath}`);
+  await exec.exec("sudo apt-get -o DPkg::Lock::Timeout=-1 update");
+  await exec.exec(`sudo apt-get -o DPkg::Lock::Timeout=-1 install -y --no-install-recommends ./${debPath}`);
 }
 
 async function installLinuxClient(version) {
@@ -89,8 +89,8 @@ async function installLinuxClient(version) {
   await exec.exec(
     '/bin/bash -c "echo \\"deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ $(lsb_release -cs) main\\" | sudo tee /etc/apt/sources.list.d/cloudflare-client.list"',
   );
-  await exec.exec("sudo apt-get update");
-  await exec.exec("sudo apt-get install -y cloudflare-warp");
+  await exec.exec("sudo apt-get -o DPkg::Lock::Timeout=-1 update");
+  await exec.exec("sudo apt-get -o DPkg::Lock::Timeout=-1install -y cloudflare-warp");
 }
 
 async function installMacOSClient(version) {


### PR DESCRIPTION
We have experienced issued installing cloudflare-warp waiting for the dpkg lock while using this action.
I chose -1 over a standard value of 30 or 60 seconds because the job will time out if execution takes too long anyway, so setting the limit here makes little sense.